### PR TITLE
test OpenMP threads

### DIFF
--- a/R/ask.R
+++ b/R/ask.R
@@ -21,6 +21,6 @@ ask <- function(threads = NULL, pct = NULL) {
     if (is.na(pct) || pct < 2L || pct > 100L) stop("pct in [2, 100] please.")
     .Call(c_set_threads, pct, TRUE, integer(0)) |> invisible()
   } else {
-    .Call(c_set_threads, as.integer(threads), FALSE, integer(0))
+    .Call(c_set_threads, as.integer(threads), FALSE, integer(0)) |> invisible()
   }
 }

--- a/inst/tinytest/test_isas.R
+++ b/inst/tinytest/test_isas.R
@@ -68,4 +68,5 @@ for (i in seq_len(nrow(ask_as))) {
 }
 
 (1 ?~ "") := "1"
+(NULL ? 1) := FALSE
 error(1 ?~ huh, "Abbreviation")

--- a/inst/tinytest/test_threads.R
+++ b/inst/tinytest/test_threads.R
@@ -1,6 +1,17 @@
 `:=` <- expect_identical
 error <- expect_error
 
+ask(1)
+new <- ask()
+new := 1L
+
+ask(pct = 100)
+pct <- ask()
+ask(1)
+ask(0)
+threads <- ask()
+pct := threads
+
 error(ask(threads = 1, pct = 1), "not both")
 error(ask(pct = c(1, 2)), "Scalar")
 error(ask(pct = 101), "[0, 100]")

--- a/src/isas.c
+++ b/src/isas.c
@@ -20,7 +20,7 @@ SEXPTYPE abb2type(S abb) {
     if (!strcmp(s, AbbCoerceTable[i].abb))
       return (SEXPTYPE) AbbCoerceTable[i].type;
   }
-  Rf_errorcall(R_NilValue, "Abbreviation not found"); // x ?~ blabla
+  Rf_errorcall(R_NilValue, "Abbreviation not found"); // x ?~ bla
   //return (SEXPTYPE) -1;
 }
 
@@ -40,8 +40,8 @@ static inline S as(S x, S fml) {
 
 S isas(S x, S fml) {
   switch(TYPEOF(fml)) {
-  case SYMSXP: return is(x, fml); // x ? .
-  case LANGSXP: return as(x, fml); // x ?~ .
-  default: return R_NilValue;
+  case SYMSXP: return is(x, fml);
+  case LANGSXP: return as(x, fml);
+  default: return Rf_ScalarLogical(0); // NULL ? NULL opens help, always false
   }
 }


### PR DESCRIPTION
- CRAN sets OpenMP to 2 by default.
- `ask` sets to 50% of available cores, varying for the CI (?)/